### PR TITLE
Multiline posts

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,8 +1,12 @@
 <h1> Create a post here ! </h1>
 
 <% @posts.reverse_each do |post| %>
-  <p><%= post.message %></p>
+  <div class="post" id="post<%= post.id %>">
+  <% post.message.split("\n").each_with_index do |line, index| %>
+    <p><%= line %></p>
+  <% end %>
   <p><%= post.created_at %></p>
+  </div>
 <% end %>
 
 <%= link_to new_post_path do %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,6 @@
 <%= form_for @post do |form| %>
   <%= form.label :message %>
-  <%= form.text_field :message %>
+  <%= form.text_area :message %>
 
   <%= form.submit "Submit" %>
 <% end %>

--- a/spec/features/posts_view_spec.rb
+++ b/spec/features/posts_view_spec.rb
@@ -9,4 +9,15 @@ RSpec.feature "Post", type: :feature do
     expect(page).to have_content("Hello, world!")
     expect(page).to have_content("UTC")
   end
+
+  scenario "Posts with mutliple lines are displayed in multiple lines" do
+    visit "/posts"
+    click_link "New post"
+    fill_in "Message", with: "Hello, world!\nThis is a new line\nAnd another line."
+    click_button "Submit"
+    expect(page).to have_selector("p", text: "Hello, world!")
+    expect(page).to have_selector("p", text: "This is a new line")
+    expect(page).to have_selector("p", text: "And another line.")
+    expect(page).not_to have_selector("p", text: "Hello, world!\nThis is a new line\nAnd another line.")
+  end
 end


### PR DESCRIPTION

- Updated app/views/posts/new.html.erb: Input is now a text area to allow input of multiple lines
- Updated spec/features/posts_view_spec.rb: add scenario to test that multi-line posts are displayed with each line on a seperate line
- Updated app/views/posts/index.html.erb: Wrapped a post in a div, split a post message into its lines and create a p element tag for each of them. Test passes.
